### PR TITLE
"Repeat" command

### DIFF
--- a/command_parser.py
+++ b/command_parser.py
@@ -16,7 +16,7 @@ _REGEX_TIME_CONTROL = re.compile('(\d+)t')
 
 def parse(cmd):
     if cmd == '':
-        return commands.Frequent(0)
+        return commands.Repeat()
 
     elif len(cmd) == 1 and cmd.isdigit():
         rank = int(cmd)

--- a/commands.py
+++ b/commands.py
@@ -30,6 +30,9 @@ def _command_type(name, fields):
 ### Public
 
 # TODO Can I do any type checking?
+# TODO documentation
+
+Repeat = _command_type('Repeat', '')
 
 # navigating the tree
 Up = _command_type('Up', 'distance')

--- a/test_command_parser.py
+++ b/test_command_parser.py
@@ -4,7 +4,8 @@ import pytest
 
 
 @pytest.mark.parametrize('input,expected', [
-    ('', commands.Frequent(0)),
+    ('', commands.Repeat()),
+
     ('0', commands.Frequent(0)),
     ('1', commands.Frequent(1)),
     ('5', commands.Frequent(5)),

--- a/wazir.py
+++ b/wazir.py
@@ -83,6 +83,7 @@ def main_loop(all_games):
 
     os.system('clear')
     print('\n')
+    cmd = None
     while True:
         node, num_games = update_tree(all_games, using_filters, path)
         show(node)
@@ -96,7 +97,16 @@ def main_loop(all_games):
         output = ''
 
         # TODO encapsulate state into one object, write eval()
+        last_cmd = cmd
         cmd = parse(raw_cmd)
+
+        if commands.Repeat.isinstance(cmd):
+            if last_cmd:
+                cmd = last_cmd
+            else:
+                # TODO fail more gracefully
+                raise Exception('no last command')
+
         if commands.Root.isinstance(cmd):
             path = []
         elif commands.Up.isinstance(cmd):


### PR DESCRIPTION
Replacing #10 

Not sure how best to deal with this sort of thing...

- branched `short-names` from `master`
- squash-merged with PR #9
- branched `repeat-command` from `short-names`
- PR #10 had conflicts